### PR TITLE
Deprecate cached_property

### DIFF
--- a/isimip_utils/utils.py
+++ b/isimip_utils/utils.py
@@ -28,7 +28,8 @@ class cached_property(_cached_property):
 
     def __get__(self, instance, cls=None):
         warnings.warn(
-            "isimip-utils.utils.cached_property is deprecated, use functools.cached_property instead.",
+            'isimip-utils.utils.cached_property is deprecated and will be removed in 2.1.0, '
+            'use functools.cached_property instead.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/isimip_utils/utils.py
+++ b/isimip_utils/utils.py
@@ -1,5 +1,6 @@
 """Additional utility functions for ISIMIP tools."""
-from collections.abc import Callable
+import warnings
+from functools import cached_property as _cached_property
 from pathlib import Path
 from typing import Any, Literal
 
@@ -21,32 +22,17 @@ class Singleton:
         return cls._instance
 
 
-class cached_property:
-    """Decorator that converts a method into a cached property.
+class cached_property(_cached_property):
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
 
-    The property value is computed once and then cached as an instance attribute.
-    Subsequent accesses return the cached value without re-computing.
-
-    Simplified version of
-    [Django's cached_property](https://github.com/django/django/blob/main/django/utils/functional.py).
-    """
-
-    name: str | None = None
-
-    def __init__(self, func: Callable) -> None:
-        self.func = func
-
-    def __set_name__(self, owner: type, name: str) -> None:
-        if self.name is None:
-            self.name = name
-        else:
-            raise TypeError("Cannot assign the same cached_property to two different names")
-
-    def __get__(self, instance: Any, cls: type | None = None) -> Any:
-        if instance is None:
-            return self
-        value = instance.__dict__[self.name] = self.func(instance)
-        return value
+    def __get__(self, instance, cls=None):
+        warnings.warn(
+            "isimip-utils.utils.cached_property is deprecated, use functools.cached_property instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().__get__(instance, cls)
 
 
 def exclude_path(exclude: list[str] | None, path: Path | str, match: Literal['any', 'all'] = 'any') -> bool:


### PR DESCRIPTION
This PR removes `cached_property` since the functionality is provided by [functool.cached_property](https://docs.python.org/3/library/functools.html#functools.cached_property) and adds a `DeprecationWarning`.